### PR TITLE
[TASK] Update OTRS to 5.0.28

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['otrs']['version'] = '5.0.26'
+default['otrs']['version'] = '5.0.28'
 default['otrs']['fqdn'] = 'otrs.typo3.org'
 
 default['otrs']['kernel_config']['email'] = 'admin@typo3.org'


### PR DESCRIPTION
------------------------------------------------------------------

OTRS Security Advisory 2018-02           <security at otrs.org>

------------------------------------------------------------------

ID:            OSA-2018-02 
Date:          2018-06-12
Title:         Information Disclosure
Severity:      4.1 Medium
Fixed in:      OTRS 6.0.8
URL:           https://community.otrs.com/security-advisory-2018-02-security-update-for-otrs-framework/
References:    CVE-2018-11563               

  
To read the entire Security Advisory please follow this link.


https://community.otrs.com/security-advisory-2018-02-security-update-for-otrs-framework/
